### PR TITLE
Add `addresses` field to person/organisation

### DIFF
--- a/schemas/includes/organisation.json
+++ b/schemas/includes/organisation.json
@@ -58,6 +58,12 @@
     "mailing_address": {
       "$ref": "address.json"
     },
+    "addresses": {
+      "type": "array",
+      "items": {
+        "$ref": "address-with-type.json"
+      }
+    },
     "industry_codes": {
       "type": "array",
       "items": {

--- a/schemas/includes/person.json
+++ b/schemas/includes/person.json
@@ -64,6 +64,12 @@
     "mailing_address": {
       "$ref": "address.json"
     },
+    "addresses": {
+      "type": "array",
+      "items": {
+        "$ref": "address-with-type.json"
+      }
+    },
     "industry_codes": {
       "type": "array",
       "items": {

--- a/spec/sample-data/invalid/includes/address-with-type/enum_mismatch-type.json
+++ b/spec/sample-data/invalid/includes/address-with-type/enum_mismatch-type.json
@@ -1,0 +1,6 @@
+{
+  "type": "foobar",
+  "address": {
+    "street_address": "123 Foo Street"
+  }
+}

--- a/spec/sample-data/invalid/includes/address-with-type/missing-address.json
+++ b/spec/sample-data/invalid/includes/address-with-type/missing-address.json
@@ -1,0 +1,3 @@
+{
+  "type": "unknown"
+}

--- a/spec/sample-data/invalid/includes/address-with-type/missing-type.json
+++ b/spec/sample-data/invalid/includes/address-with-type/missing-type.json
@@ -1,0 +1,5 @@
+{
+  "address": {
+    "street_address": "123 Foo Street"
+  }
+}

--- a/spec/sample-data/invalid/includes/organisation/type_mismatch-addresses.json
+++ b/spec/sample-data/invalid/includes/organisation/type_mismatch-addresses.json
@@ -1,0 +1,4 @@
+{
+  "name": "Alex Smith",
+  "addresses": "123 Foo Street"
+}

--- a/spec/sample-data/invalid/includes/person/type_mismatch-addresses.json
+++ b/spec/sample-data/invalid/includes/person/type_mismatch-addresses.json
@@ -1,0 +1,4 @@
+{
+  "name": "Alex Smith",
+  "addresses": "123 Foo Street"
+}

--- a/spec/sample-data/valid/includes/address-with-type-01.json
+++ b/spec/sample-data/valid/includes/address-with-type-01.json
@@ -1,0 +1,4 @@
+{
+  "type": "mailing",
+  "address": "123 Foo Street"
+}

--- a/spec/sample-data/valid/includes/address-with-type-02.json
+++ b/spec/sample-data/valid/includes/address-with-type-02.json
@@ -1,0 +1,6 @@
+{
+  "type": "unknown",
+  "address": {
+    "street_address": "123 Foo Street"
+  }
+}

--- a/spec/sample-data/valid/includes/organisation-03.json
+++ b/spec/sample-data/valid/includes/organisation-03.json
@@ -1,0 +1,12 @@
+{
+  "name": "Foo International",
+  "addresses": [
+    {
+      "type": "unknown",
+      "address": {
+        "street_address": "123 Foo Street",
+        "locality": "London"
+      }
+    }
+  ]
+}

--- a/spec/sample-data/valid/includes/person-06.json
+++ b/spec/sample-data/valid/includes/person-06.json
@@ -1,0 +1,12 @@
+{
+  "name": "Alex Smith",
+  "addresses": [
+    {
+      "type": "unknown",
+      "address": {
+        "street_address": "123 Foo Street",
+        "locality": "London"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
We previously added this to companies and unknown entities, and it's useful to have "unknown" address for persons and organisations too.