### PR TITLE
Remove reference to `gh-pages` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Write schema files with embedded references (for Docson):
 
     rake build
 
-The `gh-pages` branch is hard-coded to refer to one of these schema files.
-
 ## Test
 
 Run tests:


### PR DESCRIPTION
It was only showing one schema, so retiring it for now.