### PR TITLE
Pin bundle version to last one compatible with ruby < 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ rvm:
   - 2.6
 before_install:
   - gem update --system 2.7.8
-  - gem install bundler
+  - gem install bundler -v 1.17.3
 before_script: bin/rake build format_json && git status -s && [[ -z $(git status -s) ]]


### PR DESCRIPTION
We are stuck supporting some earlier ruby versions for now. It might be better to pin the bundler version for earlier ruby versions _only_ and still install latest bundler for >= 2.3, but that's a bit more faff so going with this for now.