### PR TITLE
Disallow extra properties on total-shares

### DIFF
--- a/build/accounts-statement-schema.json
+++ b/build/accounts-statement-schema.json
@@ -795,6 +795,7 @@
           "minLength": 1
         }
       },
+      "additionalProperties": false,
       "required": [
         "number"
       ]

--- a/build/alternate-registration-schema.json
+++ b/build/alternate-registration-schema.json
@@ -705,6 +705,7 @@
           "minLength": 1
         }
       },
+      "additionalProperties": false,
       "required": [
         "number"
       ]

--- a/build/company-schema.json
+++ b/build/company-schema.json
@@ -537,6 +537,7 @@
           "minLength": 1
         }
       },
+      "additionalProperties": false,
       "required": [
         "number"
       ]

--- a/build/control-statement-schema.json
+++ b/build/control-statement-schema.json
@@ -991,6 +991,7 @@
           "minLength": 1
         }
       },
+      "additionalProperties": false,
       "required": [
         "number"
       ]

--- a/build/filing-schema.json
+++ b/build/filing-schema.json
@@ -718,6 +718,7 @@
           "minLength": 1
         }
       },
+      "additionalProperties": false,
       "required": [
         "number"
       ]

--- a/build/gazette-notice-schema.json
+++ b/build/gazette-notice-schema.json
@@ -1349,6 +1349,7 @@
           "minLength": 1
         }
       },
+      "additionalProperties": false,
       "required": [
         "number"
       ]

--- a/build/licence-schema.json
+++ b/build/licence-schema.json
@@ -727,6 +727,7 @@
           "minLength": 1
         }
       },
+      "additionalProperties": false,
       "required": [
         "number"
       ]

--- a/build/register-entry-schema.json
+++ b/build/register-entry-schema.json
@@ -938,6 +938,7 @@
           "minLength": 1
         }
       },
+      "additionalProperties": false,
       "required": [
         "number"
       ]

--- a/build/sanctioned-entity-schema.json
+++ b/build/sanctioned-entity-schema.json
@@ -936,6 +936,7 @@
           "minLength": 1
         }
       },
+      "additionalProperties": false,
       "required": [
         "number"
       ]

--- a/build/subsequent-registration-schema.json
+++ b/build/subsequent-registration-schema.json
@@ -706,6 +706,7 @@
           "minLength": 1
         }
       },
+      "additionalProperties": false,
       "required": [
         "number"
       ]

--- a/build/supplier-relationship-schema.json
+++ b/build/supplier-relationship-schema.json
@@ -699,6 +699,7 @@
           "minLength": 1
         }
       },
+      "additionalProperties": false,
       "required": [
         "number"
       ]

--- a/build/trademark-registration-schema.json
+++ b/build/trademark-registration-schema.json
@@ -814,6 +814,7 @@
           "minLength": 1
         }
       },
+      "additionalProperties": false,
       "required": [
         "number"
       ]

--- a/schemas/includes/total-shares.json
+++ b/schemas/includes/total-shares.json
@@ -11,6 +11,7 @@
       "minLength": 1
     }
   },
+  "additionalProperties": false,
   "required": [
     "number"
   ]

--- a/spec/sample-data/invalid/includes/total-shares/additional-foo.json
+++ b/spec/sample-data/invalid/includes/total-shares/additional-foo.json
@@ -1,0 +1,5 @@
+{
+  "number": 100,
+  "share_class": "A",
+  "foo": "bar"
+}

--- a/spec/sample-data/valid/includes/total-shares-01.json
+++ b/spec/sample-data/valid/includes/total-shares-01.json
@@ -1,0 +1,4 @@
+{
+  "number": 100,
+  "share_class": "A"
+}


### PR DESCRIPTION
Total shares Rails model actually errors if initialised with extra properties. This will hopefully let us catch these at fetch rather than ingestion.