### PR TITLE
feat(schema): Add validation pattern for industry-code

### DIFF
--- a/build/accounts-statement-schema.json
+++ b/build/accounts-statement-schema.json
@@ -887,7 +887,9 @@
           "type": "string"
         },
         "code": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[a-zA-Z0-9]"
         },
         "code_scheme_id": {
           "type": "string",

--- a/build/alternate-registration-schema.json
+++ b/build/alternate-registration-schema.json
@@ -797,7 +797,9 @@
           "type": "string"
         },
         "code": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[a-zA-Z0-9]"
         },
         "code_scheme_id": {
           "type": "string",

--- a/build/company-schema.json
+++ b/build/company-schema.json
@@ -629,7 +629,9 @@
           "type": "string"
         },
         "code": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[a-zA-Z0-9]"
         },
         "code_scheme_id": {
           "type": "string",

--- a/build/control-statement-schema.json
+++ b/build/control-statement-schema.json
@@ -1083,7 +1083,9 @@
           "type": "string"
         },
         "code": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[a-zA-Z0-9]"
         },
         "code_scheme_id": {
           "type": "string",

--- a/build/filing-schema.json
+++ b/build/filing-schema.json
@@ -811,7 +811,9 @@
           "type": "string"
         },
         "code": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[a-zA-Z0-9]"
         },
         "code_scheme_id": {
           "type": "string",

--- a/build/gazette-notice-schema.json
+++ b/build/gazette-notice-schema.json
@@ -1441,7 +1441,9 @@
           "type": "string"
         },
         "code": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[a-zA-Z0-9]"
         },
         "code_scheme_id": {
           "type": "string",

--- a/build/licence-schema.json
+++ b/build/licence-schema.json
@@ -819,7 +819,9 @@
           "type": "string"
         },
         "code": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[a-zA-Z0-9]"
         },
         "code_scheme_id": {
           "type": "string",

--- a/build/register-entry-schema.json
+++ b/build/register-entry-schema.json
@@ -295,7 +295,9 @@
           "type": "string"
         },
         "code": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[a-zA-Z0-9]"
         },
         "code_scheme_id": {
           "type": "string",

--- a/build/sanctioned-entity-schema.json
+++ b/build/sanctioned-entity-schema.json
@@ -293,7 +293,9 @@
           "type": "string"
         },
         "code": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[a-zA-Z0-9]"
         },
         "code_scheme_id": {
           "type": "string",

--- a/build/subsequent-registration-schema.json
+++ b/build/subsequent-registration-schema.json
@@ -798,7 +798,9 @@
           "type": "string"
         },
         "code": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[a-zA-Z0-9]"
         },
         "code_scheme_id": {
           "type": "string",

--- a/build/supplier-relationship-schema.json
+++ b/build/supplier-relationship-schema.json
@@ -791,7 +791,9 @@
           "type": "string"
         },
         "code": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[a-zA-Z0-9]"
         },
         "code_scheme_id": {
           "type": "string",

--- a/build/trademark-registration-schema.json
+++ b/build/trademark-registration-schema.json
@@ -906,7 +906,9 @@
           "type": "string"
         },
         "code": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[a-zA-Z0-9]"
         },
         "code_scheme_id": {
           "type": "string",

--- a/schemas/includes/industry-code.json
+++ b/schemas/includes/industry-code.json
@@ -7,7 +7,9 @@
       "type": "string"
     },
     "code": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1,
+      "pattern": "[a-zA-Z0-9]"
     },
     "code_scheme_id": {
       "type": "string",


### PR DESCRIPTION
Add JSON schema validation for industry code field requiring:
- At least one alphanumeric character anywhere in the string
- Minimum length of 1 character
- Allows any other characters including whitespace aslong as there is one alphanumeric character somewhere

Pattern added: "[a-zA-Z0-9]"